### PR TITLE
Expose logger name

### DIFF
--- a/sink.go
+++ b/sink.go
@@ -152,6 +152,11 @@ func (s PtermSink) WithOutput(output io.Writer) *PtermSink {
 	return newSink
 }
 
+// GetName returns the currently configured scope name
+func (s PtermSink) GetName() string {
+	return s.scope
+}
+
 func (s *PtermSink) toMap(kvs ...interface{}) map[string]interface{} {
 	if len(kvs)%2 == 1 {
 		// Ensure an odd number of items here does not corrupt the list


### PR DESCRIPTION
## Summary

* Adds `GetName()` method that returns the current scope name.

Might be useful for sinks that wrap PtermSink.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
