### PR TITLE
Support enabling/disabling log levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ If you like to customize the levels or styling, you could do something like this
 ```go
 func main() {
 	sink := plogr.NewPtermSink()
-	sink.LevelPrinters[3] = pterm.Debug
-	sink.LevelPrinters[2] = plogr.DefaultLevelPrinters[0]
-	sink.LevelPrinters[1] = pterm.Success
-	sink.LevelPrinters[0] = pterm.Warning
+	sink.LevelPrinters[3] = plogr.PrinterTuple{Printer: pterm.Debug, Enabled: true}
+	sink.LevelPrinters[2] = plogr.PrinterTuple{Printer: plogr.DefaultLevelPrinters[0], Enabled: true}
+	sink.LevelPrinters[1] = plogr.PrinterTuple{Printer: pterm.Success, Enabled: true}
+	sink.LevelPrinters[0] = plogr.PrinterTuple{Printer: pterm.Warning, Enabled: true}
 
 	logger := logr.New(sink)
 	logger.V(0).WithName("main").Info("Warning message")

--- a/examples/example_test.go
+++ b/examples/example_test.go
@@ -47,10 +47,10 @@ func TestExample_PtermSink_Debug(t *testing.T) {
 
 func TestExample_PtermSink_MoreLevels(t *testing.T) {
 	sink := plogr.NewPtermSink()
-	sink.LevelPrinters[3] = pterm.Debug
-	sink.LevelPrinters[2] = plogr.DefaultLevelPrinters[0]
-	sink.LevelPrinters[1] = pterm.Success
-	sink.LevelPrinters[0] = pterm.Warning
+	sink.LevelPrinters[3] = plogr.PrinterTuple{Printer: pterm.Debug, Enabled: true}
+	sink.LevelPrinters[2] = plogr.PrinterTuple{Printer: plogr.DefaultLevelPrinters[0], Enabled: true}
+	sink.LevelPrinters[1] = plogr.PrinterTuple{Printer: pterm.Success, Enabled: true}
+	sink.LevelPrinters[0] = plogr.PrinterTuple{Printer: pterm.Warning, Enabled: true}
 	logger := logr.New(sink)
 	logger.V(0).WithName("main").Info("Warning message")
 	logger.V(1).WithName("app").Info("Success message")

--- a/sink.go
+++ b/sink.go
@@ -152,8 +152,8 @@ func (s PtermSink) WithOutput(output io.Writer) *PtermSink {
 	return newSink
 }
 
-// GetName returns the currently configured scope name
-func (s PtermSink) GetName() string {
+// Name returns the currently configured scope name
+func (s PtermSink) Name() string {
 	return s.scope
 }
 

--- a/sink_test.go
+++ b/sink_test.go
@@ -175,3 +175,17 @@ func TestPtermSink_SetOutput(t *testing.T) {
 	// The expected output is actually from "golden" execution, but it should notify us on unnoticed changes
 	assert.Equal(t, doubleLine, out.String())
 }
+
+func TestPtermSink_WithLevelEnabled(t *testing.T) {
+	out := &bytes.Buffer{}
+
+	rootSink := NewPtermSink()
+	rootSink.SetOutput(out)
+
+	rootLogger := logr.New(rootSink.WithLevelEnabled(1, false))
+	rootLogger.Info("info message")
+	rootLogger.V(1).Info("debug message")
+
+	assert.Contains(t, out.String(), "info message")
+	assert.NotContains(t, out.String(), "debug message")
+}


### PR DESCRIPTION
## Summary

* Adds new method `WithLevelEnabled` that enables/disables logging levels without adding or removing pterm's PrefixPrinter
  * Keeps the default Debug level enabled to avoid breaking change here too.
* Adds the `PrinterTuple` type. This breaks the `LevelPrinters` map property.
* Renames `GetName()` to `Name()`

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
