### PR TITLE
Support enabling/disabling logging levels (Alternative implementation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ If you like to customize the levels or styling, you could do something like this
 ```go
 func main() {
 	sink := plogr.NewPtermSink()
-	sink.LevelPrinters[3] = plogr.PrinterTuple{Printer: pterm.Debug, Enabled: true}
-	sink.LevelPrinters[2] = plogr.PrinterTuple{Printer: plogr.DefaultLevelPrinters[0], Enabled: true}
-	sink.LevelPrinters[1] = plogr.PrinterTuple{Printer: pterm.Success, Enabled: true}
-	sink.LevelPrinters[0] = plogr.PrinterTuple{Printer: pterm.Warning, Enabled: true}
+	sink.LevelPrinters[3] = pterm.Debug
+	sink.LevelPrinters[2] = plogr.DefaultLevelPrinters[0]
+	sink.LevelPrinters[1] = pterm.Success
+	sink.LevelPrinters[0] = pterm.Warning
 
 	logger := logr.New(sink)
 	logger.V(0).WithName("main").Info("Warning message")

--- a/examples/example_test.go
+++ b/examples/example_test.go
@@ -47,10 +47,10 @@ func TestExample_PtermSink_Debug(t *testing.T) {
 
 func TestExample_PtermSink_MoreLevels(t *testing.T) {
 	sink := plogr.NewPtermSink()
-	sink.LevelPrinters[3] = plogr.PrinterTuple{Printer: pterm.Debug, Enabled: true}
-	sink.LevelPrinters[2] = plogr.PrinterTuple{Printer: plogr.DefaultLevelPrinters[0], Enabled: true}
-	sink.LevelPrinters[1] = plogr.PrinterTuple{Printer: pterm.Success, Enabled: true}
-	sink.LevelPrinters[0] = plogr.PrinterTuple{Printer: pterm.Warning, Enabled: true}
+	sink.LevelPrinters[3] = pterm.Debug
+	sink.LevelPrinters[2] = plogr.DefaultLevelPrinters[0]
+	sink.LevelPrinters[1] = pterm.Success
+	sink.LevelPrinters[0] = pterm.Warning
 	logger := logr.New(sink)
 	logger.V(0).WithName("main").Info("Warning message")
 	logger.V(1).WithName("app").Info("Success message")

--- a/sink.go
+++ b/sink.go
@@ -13,7 +13,7 @@ import (
 // PtermSink implements logr.LogSink.
 type PtermSink struct {
 	// LevelPrinters maps a pterm.PrefixPrinter to each supported log level.
-	LevelPrinters map[int]PrinterTuple
+	LevelPrinters map[int]pterm.PrefixPrinter
 	// ErrorPrinter is the instance that formats and styles error messages.
 	ErrorPrinter pterm.PrefixPrinter
 
@@ -21,14 +21,6 @@ type PtermSink struct {
 	messageFormatter func(msg string, keysAndValues map[string]interface{}) string
 	scope            string
 	writer           io.Writer
-}
-
-// PrinterTuple contains fields relevant for configuring a logging Printer.
-type PrinterTuple struct {
-	// Enabled indicates whether a printer is enabled
-	Enabled bool
-	// Printer contains the actual pterm.PrefixPrinter.
-	Printer pterm.PrefixPrinter
 }
 
 // ScopeSeparator delimits logger names.
@@ -59,20 +51,13 @@ var DefaultFormatter = func(msg string, keysAndValues map[string]interface{}) st
 // PtermSink.LevelPrinters and PtermSink.ErrorPrinter are initialized with DefaultLevelPrinters resp. pterm.Error.
 // PtermSink.KeyValueColor is the color that is applied when logging keys and values and defaults to pterm.FgGray.
 func NewPtermSink() PtermSink {
-	sink := PtermSink{
-		LevelPrinters:    map[int]PrinterTuple{},
+	return PtermSink{
+		LevelPrinters:    DefaultLevelPrinters,
 		ErrorPrinter:     pterm.Error,
 		keyValues:        map[string]interface{}{},
 		messageFormatter: DefaultFormatter,
 		writer:           os.Stdout,
 	}
-	for level, printer := range DefaultLevelPrinters {
-		sink.LevelPrinters[level] = PrinterTuple{
-			Printer: printer,
-			Enabled: true,
-		}
-	}
-	return sink
 }
 
 // Init implements logr.LogSink.
@@ -83,17 +68,14 @@ func (s PtermSink) Init(_ logr.RuntimeInfo) {
 // Enabled implements logr.LogSink.
 // It will only return true if the PtermSink.LevelPrinters contains the same key as given level.
 func (s PtermSink) Enabled(level int) bool {
-	tuple, exists := s.LevelPrinters[level]
-	if exists {
-		return tuple.Enabled
-	}
-	return false
+	_, exists := s.LevelPrinters[level]
+	return exists
 }
 
 // Info implements logr.LogSink.
 func (s PtermSink) Info(level int, msg string, kvs ...interface{}) {
-	tuple := s.LevelPrinters[level]
-	s.print(tuple.Printer, kvs, msg)
+	printer := s.LevelPrinters[level]
+	s.print(printer, kvs, msg)
 }
 
 // Error implements logr.LogSink.
@@ -136,18 +118,14 @@ func (s PtermSink) WithName(name string) logr.LogSink {
 	newSink := &PtermSink{
 		scope:            s.joinName(s.scope, name),
 		keyValues:        s.keyValues,
-		LevelPrinters:    map[int]PrinterTuple{},
+		LevelPrinters:    map[int]pterm.PrefixPrinter{},
 		ErrorPrinter:     s.ErrorPrinter,
 		messageFormatter: s.messageFormatter,
 		writer:           s.writer,
 	}
-	for level, tuple := range s.LevelPrinters {
-		printer := tuple.Printer
+	for level, printer := range s.LevelPrinters {
 		newPrinter := printer.WithScope(pterm.Scope{Text: name, Style: printer.Scope.Style})
-		newSink.LevelPrinters[level] = PrinterTuple{
-			Printer: *newPrinter,
-			Enabled: tuple.Enabled,
-		}
+		newSink.LevelPrinters[level] = *newPrinter
 	}
 	newSink.ErrorPrinter.Scope.Text = newSink.scope
 	return newSink
@@ -177,23 +155,6 @@ func (s PtermSink) WithOutput(output io.Writer) *PtermSink {
 // Name returns the currently configured scope name
 func (s PtermSink) Name() string {
 	return s.scope
-}
-
-// WithLevelEnabled returns a new instance that sets the given level equal to the given flag.
-func (s PtermSink) WithLevelEnabled(level int, enabled bool) *PtermSink {
-	newSink := &PtermSink{
-		scope:            s.scope,
-		keyValues:        s.keyValues,
-		LevelPrinters:    s.LevelPrinters,
-		ErrorPrinter:     s.ErrorPrinter,
-		messageFormatter: s.messageFormatter,
-		writer:           s.writer,
-	}
-	newSink.LevelPrinters[level] = PrinterTuple{
-		Printer: s.LevelPrinters[level].Printer,
-		Enabled: enabled,
-	}
-	return newSink
 }
 
 func (s *PtermSink) toMap(kvs ...interface{}) map[string]interface{} {

--- a/sink_test.go
+++ b/sink_test.go
@@ -175,3 +175,17 @@ func TestPtermSink_SetOutput(t *testing.T) {
 	// The expected output is actually from "golden" execution, but it should notify us on unnoticed changes
 	assert.Equal(t, doubleLine, out.String())
 }
+
+func TestPtermSink_WithLevelEnabled(t *testing.T) {
+	out := &bytes.Buffer{}
+
+	rootSink := NewPtermSink()
+	rootSink.SetOutput(out)
+
+	rootLogger := logr.New(rootSink.SetLevelEnabled(1, false))
+	rootLogger.Info("info message")
+	rootLogger.V(1).Info("debug message")
+
+	assert.Contains(t, out.String(), "info message")
+	assert.NotContains(t, out.String(), "debug message")
+}

--- a/sink_test.go
+++ b/sink_test.go
@@ -175,17 +175,3 @@ func TestPtermSink_SetOutput(t *testing.T) {
 	// The expected output is actually from "golden" execution, but it should notify us on unnoticed changes
 	assert.Equal(t, doubleLine, out.String())
 }
-
-func TestPtermSink_WithLevelEnabled(t *testing.T) {
-	out := &bytes.Buffer{}
-
-	rootSink := NewPtermSink()
-	rootSink.SetOutput(out)
-
-	rootLogger := logr.New(rootSink.WithLevelEnabled(1, false))
-	rootLogger.Info("info message")
-	rootLogger.V(1).Info("debug message")
-
-	assert.Contains(t, out.String(), "info message")
-	assert.NotContains(t, out.String(), "debug message")
-}


### PR DESCRIPTION
## Summary

* Alternative implementation of #8 with a dedicated map that avoids awkward breaking changes.

The way it works now is that all configured levels are enabled by default, unless explicitly disabled.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
