### PR TITLE
Ignore nil errors to be added as a field

### DIFF
--- a/sink.go
+++ b/sink.go
@@ -95,9 +95,11 @@ func (s PtermSink) Info(level int, msg string, kvs ...interface{}) {
 }
 
 // Error implements logr.LogSink.
-// The given err is appended to the keys and values array with the "error" key.
+// The given err is appended to the keys and values array with the "error" key, but only if err is non-nil.
 func (s PtermSink) Error(err error, msg string, kvs ...interface{}) {
-	kvs = append(kvs, "error", err)
+	if err != nil {
+		kvs = append(kvs, "error", err)
+	}
 	s.print(s.ErrorPrinter, kvs, msg)
 }
 


### PR DESCRIPTION
## Summary

Small cosmetic improvement: Ignore errors if they are nil when calling `Error`. Sometimes, one rather adds the stringified error message itself as error then having the error as a field.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
