### PR TITLE
Use WithWriter from upstream pterm

### DIFF
--- a/sink_test.go
+++ b/sink_test.go
@@ -148,16 +148,17 @@ func TestPtermSink_toMap(t *testing.T) {
 }
 
 func TestPtermSink_WithOutput(t *testing.T) {
-	out := bytes.Buffer{}
+	old, out := bytes.Buffer{}, bytes.Buffer{}
 
-	sink := NewPtermSink()
+	sink := NewPtermSink().WithOutput(&old)
 	newSink := sink.WithOutput(&out)
-	assert.NotEqual(t, sink.writer, newSink.writer)
 
+	sink.Info(0, "shouldn't be included in new sink")
 	newSink.Info(0, "message", "key", "value")
 
 	// The expected output is actually from "golden" execution, but it should notify us on unnoticed changes
-	assert.Equal(t, "\x1b[30;46m\x1b[30;46m  INFO   \x1b[0m\x1b[0m \x1b[96m\x1b[96mmessage \x1b[90m(key=\"value\")\x1b[0m\x1b[96m\x1b[0m\x1b[0m\n", out.String())
+	assert.Equal(t, "\x1b[30;46m\x1b[30;46m  INFO   \x1b[0m\x1b[0m \x1b[96m\x1b[96mshouldn't be included in new sink\x1b[0m\x1b[0m\n", old.String(), "old sink")
+	assert.Equal(t, "\x1b[30;46m\x1b[30;46m  INFO   \x1b[0m\x1b[0m \x1b[96m\x1b[96mmessage \x1b[90m(key=\"value\")\x1b[0m\x1b[96m\x1b[0m\x1b[0m\n", out.String(), "new sink")
 }
 
 func TestPtermSink_SetOutput(t *testing.T) {
@@ -165,7 +166,6 @@ func TestPtermSink_SetOutput(t *testing.T) {
 
 	sink := NewPtermSink()
 	newSink := sink.SetOutput(&out)
-	assert.Equal(t, sink.writer, newSink.writer)
 
 	sink.Info(0, "message", "key", "value")
 	newSink.Info(0, "message", "key", "value")


### PR DESCRIPTION
## Summary

* Instead of keeping a `io.Writer` reference in the sink, we'll use `pterm.PrefixPrinter.WithWriter()` to set the output writer.
* This should(tm) not be causing issues with existing setups, so I think it's safe to upgrade.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
