### PR TITLE
Add FallbackPrinter

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ func main() {
 
 That means whenever you want to show informational messages, you'd have to set the logging level to `2` in your code base.
 Alternatively, without breaking the code base, append levels like `success` to the LevelPrinters to your desired level, disregarding the verbosity increase though.
+For a logging library, it remains questionable though if you'd like to maintain warnings and success levels via plogr or whether they're better explicitly invoked in pterm.
 
 The error printer can be customized as well, but it has its own field.
 

--- a/examples/example_test.go
+++ b/examples/example_test.go
@@ -1,3 +1,4 @@
+//go:build examples
 // +build examples
 
 package examples
@@ -46,7 +47,7 @@ func TestExample_PtermSink_Debug(t *testing.T) {
 }
 
 func TestExample_PtermSink_MoreLevels(t *testing.T) {
-	sink := plogr.NewPtermSink()
+	sink := plogr.NewPtermSink().WithFallbackPrinter(pterm.Debug)
 	sink.LevelPrinters[3] = pterm.Debug
 	sink.LevelPrinters[2] = plogr.DefaultLevelPrinters[0]
 	sink.LevelPrinters[1] = pterm.Success
@@ -56,4 +57,5 @@ func TestExample_PtermSink_MoreLevels(t *testing.T) {
 	logger.V(1).WithName("app").Info("Success message")
 	logger.V(2).WithName("database").Info("Info message", "key", "value")
 	logger.V(3).WithName("controller").Info("Debug message")
+	logger.V(50).WithName("fallback").Info("Fallback message")
 }

--- a/sink_test.go
+++ b/sink_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/pterm/pterm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -51,7 +52,7 @@ func TestPtermSink_WithName(t *testing.T) {
 		require.Equal(t, "", logger.GetSink().(PtermSink).scope)
 
 		newLogger := logger.WithName("scope")
-		newScope := newLogger.GetSink().(*PtermSink).scope
+		newScope := newLogger.GetSink().(PtermSink).scope
 		assert.NotEqual(t, logger.GetSink().(PtermSink).scope, newScope)
 		assert.Equal(t, "scope", newScope)
 	})
@@ -59,7 +60,7 @@ func TestPtermSink_WithName(t *testing.T) {
 		require.Equal(t, "", logger.GetSink().(PtermSink).scope)
 
 		newLogger := logger.WithName("scope").WithName("nested")
-		newScope := newLogger.GetSink().(*PtermSink).scope
+		newScope := newLogger.GetSink().(PtermSink).scope
 		assert.NotEqual(t, logger.GetSink().(PtermSink).scope, newScope)
 		assert.Equal(t, "scope:nested", newScope)
 	})
@@ -71,9 +72,14 @@ func TestPtermSink_Enabled(t *testing.T) {
 		enabled := sink.Enabled(0)
 		assert.True(t, enabled)
 	})
-	t.Run("GivenInexistingLevel_ThenReturnFalse", func(t *testing.T) {
+	t.Run("GivenNonExistingLevel_ThenReturnFalse", func(t *testing.T) {
 		enabled := sink.Enabled(10000)
 		assert.False(t, enabled)
+	})
+	t.Run("GivenNonExistingLevel_WhenFallbackPrinterDefined_ThenReturnTrue", func(t *testing.T) {
+		sink = *sink.WithFallbackPrinter(pterm.Debug)
+		enabled := sink.Enabled(10000)
+		assert.True(t, enabled)
 	})
 }
 


### PR DESCRIPTION
## Summary

* Add FallbackPrinter to support log levels that aren't defined in the sink.
* This is useful if your app expects a log level outside of your control.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
