### PR TITLE
Disable debug printer by default, update prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See [examples](./examples/example_test.go)
 
 ### Add more colors and levels
 
-By default, only level 0 (`info`) and level 1 (`debug`) are supported.
+By default, only level 0 (`info`) and level 1 (`debug`) are configured.
 
 While go-logr doesn't have names for logging levels ("info", "warning", etc), pterm does.
 Both libraries agree that verbosity is increased with higher numeric logging level.
@@ -23,11 +23,11 @@ If you like to customize the levels or styling, you could do something like this
 
 ```go
 func main() {
-	sink := plogr.NewPtermSink()
-	sink.LevelPrinters[3] = pterm.Debug
-	sink.LevelPrinters[2] = plogr.DefaultLevelPrinters[0]
-	sink.LevelPrinters[1] = pterm.Success
-	sink.LevelPrinters[0] = pterm.Warning
+	sink := plogr.NewPtermSink().
+	    SetLevelPrinter(3, pterm.Debug).
+        SetLevelPrinter(2, plogr.DefaultLevelPrinters[0]).
+        SetLevelPrinter(1, pterm.Success).
+        SetLevelPrinter(0, pterm.Warning)
 
 	logger := logr.New(sink)
 	logger.V(0).WithName("main").Info("Warning message")

--- a/sink.go
+++ b/sink.go
@@ -32,16 +32,16 @@ var ScopeSeparator = ":"
 
 // DefaultLevelPrinters contains the default pterm.PrefixPrinter for a specific log levels.
 var DefaultLevelPrinters = map[int]pterm.PrefixPrinter{
-	0: *pterm.Info.WithPrefix(pterm.Prefix{Text: " INFO  ", Style: pterm.Info.Prefix.Style}),
-	1: pterm.Debug,
+	0: *pterm.Info.WithPrefix(pterm.Prefix{Text: "  INFO  ", Style: pterm.Info.Prefix.Style}),
+	1: *pterm.Debug.WithPrefix(pterm.Prefix{Text: " DBUG/1 ", Style: pterm.Debug.Prefix.Style}),
 }
 
 // DefaultErrorPrinter is the default pterm.PrefixPrinter for the error level.
 var DefaultErrorPrinter = *pterm.Error.WithShowLineNumber(true).WithLineNumberOffset(2)
 
 // DefaultFormatter returns a string that looks as following (with colored key/values):
-//  * message
-//  * message (key="value" foo="bar")
+//   - message
+//   - message (key="value" foo="bar")
 var DefaultFormatter = func(msg string, keysAndValues map[string]interface{}) string {
 	if len(keysAndValues) <= 0 {
 		return msg
@@ -77,8 +77,8 @@ func (s PtermSink) Init(_ logr.RuntimeInfo) {
 
 // Enabled implements logr.LogSink.
 // It will return false
-//  * if LevelEnabled has a key with the level and a value "false"
-//  * if LevelPrinters does not contain the requested level as key and FallbackPrinter is nil
+//   - if LevelEnabled has a key with the level and a value "false"
+//   - if LevelPrinters does not contain the requested level as key and FallbackPrinter is nil
 func (s PtermSink) Enabled(level int) bool {
 	_, exists := s.LevelPrinters[level]
 	if exists {
@@ -177,6 +177,13 @@ func (s PtermSink) Name() string {
 // SetLevelEnabled explicitly enables or disables a logging level.
 func (s *PtermSink) SetLevelEnabled(level int, enabled bool) *PtermSink {
 	s.LevelEnabled[level] = enabled
+	return s
+}
+
+// SetLevelPrinter sets the printer for the given logging level.
+// Does not enable the given log level though.
+func (s *PtermSink) SetLevelPrinter(level int, printer pterm.PrefixPrinter) *PtermSink {
+	s.LevelPrinters[level] = printer
 	return s
 }
 

--- a/sink.go
+++ b/sink.go
@@ -33,7 +33,12 @@ var ScopeSeparator = ":"
 // DefaultLevelPrinters contains the default pterm.PrefixPrinter for a specific log levels.
 var DefaultLevelPrinters = map[int]pterm.PrefixPrinter{
 	0: *pterm.Info.WithPrefix(pterm.Prefix{Text: "  INFO  ", Style: pterm.Info.Prefix.Style}),
-	1: *pterm.Debug.WithPrefix(pterm.Prefix{Text: " DBUG/1 ", Style: pterm.Debug.Prefix.Style}),
+	1: NewDefaultDebugPrinter(1),
+}
+
+// NewDefaultDebugPrinter returns a new pterm.PrefixPrinter with a pterm.Prefix that contains the log level.
+func NewDefaultDebugPrinter(level int) pterm.PrefixPrinter {
+	return *pterm.Debug.WithPrefix(pterm.Prefix{Text: fmt.Sprintf(" DBUG/%d ", level), Style: pterm.Debug.Prefix.Style})
 }
 
 // DefaultErrorPrinter is the default pterm.PrefixPrinter for the error level.

--- a/sink.go
+++ b/sink.go
@@ -62,7 +62,7 @@ func NewPtermSink() PtermSink {
 		LevelPrinters: DefaultLevelPrinters,
 		LevelEnabled: map[int]bool{
 			0: true,
-			1: true,
+			1: false,
 		},
 		ErrorPrinter:     DefaultErrorPrinter,
 		keyValues:        map[string]interface{}{},

--- a/sink_test.go
+++ b/sink_test.go
@@ -163,8 +163,8 @@ func TestPtermSink_WithOutput(t *testing.T) {
 	newSink.Info(0, "message", "key", "value")
 
 	// The expected output is actually from "golden" execution, but it should notify us on unnoticed changes
-	assert.Equal(t, "\x1b[30;46m\x1b[30;46m  INFO   \x1b[0m\x1b[0m \x1b[96m\x1b[96mshouldn't be included in new sink\x1b[0m\x1b[0m\n", old.String(), "old sink")
-	assert.Equal(t, "\x1b[30;46m\x1b[30;46m  INFO   \x1b[0m\x1b[0m \x1b[96m\x1b[96mmessage \x1b[90m(key=\"value\")\x1b[0m\x1b[96m\x1b[0m\x1b[0m\n", out.String(), "new sink")
+	assert.Equal(t, "\x1b[30;46m\x1b[30;46m   INFO   \x1b[0m\x1b[0m \x1b[96m\x1b[96mshouldn't be included in new sink\x1b[0m\x1b[0m\n", old.String(), "old sink")
+	assert.Equal(t, "\x1b[30;46m\x1b[30;46m   INFO   \x1b[0m\x1b[0m \x1b[96m\x1b[96mmessage \x1b[90m(key=\"value\")\x1b[0m\x1b[96m\x1b[0m\x1b[0m\n", out.String(), "new sink")
 }
 
 func TestPtermSink_SetOutput(t *testing.T) {
@@ -176,7 +176,7 @@ func TestPtermSink_SetOutput(t *testing.T) {
 	sink.Info(0, "message", "key", "value")
 	newSink.Info(0, "message", "key", "value")
 
-	expected := "\x1b[30;46m\x1b[30;46m  INFO   \x1b[0m\x1b[0m \x1b[96m\x1b[96mmessage \x1b[90m(key=\"value\")\x1b[0m\x1b[96m\x1b[0m\x1b[0m\n"
+	expected := "\x1b[30;46m\x1b[30;46m   INFO   \x1b[0m\x1b[0m \x1b[96m\x1b[96mmessage \x1b[90m(key=\"value\")\x1b[0m\x1b[96m\x1b[0m\x1b[0m\n"
 	doubleLine := expected + expected
 	// The expected output is actually from "golden" execution, but it should notify us on unnoticed changes
 	assert.Equal(t, doubleLine, out.String())


### PR DESCRIPTION
## Summary

* Disables the printer for log level 1 by default
* Updates the text of the prefix from `DEBUG` to `DBUG/<level>`

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
