### PR TITLE
Remove Fallback printer

### DIFF
--- a/examples/example_test.go
+++ b/examples/example_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ccremer/plogr"
 	"github.com/go-logr/logr"
-	"github.com/pterm/pterm"
 )
 
 func TestExample_PtermSink_Error(t *testing.T) {
@@ -41,21 +40,8 @@ func TestExample_PtermSink_WithValues(t *testing.T) {
 
 func TestExample_PtermSink_Debug(t *testing.T) {
 	sink := plogr.NewPtermSink()
+	sink.SetLevelEnabled(1, true)
 	logger := logr.New(sink)
 	logger.V(5).Info("This message does not get printed", "reason", "level doesn't exist", "level", 5)
 	logger.V(1).Info("debug message that actually gets printed", "key", "value", "level", 1)
-}
-
-func TestExample_PtermSink_MoreLevels(t *testing.T) {
-	sink := plogr.NewPtermSink().WithFallbackPrinter(pterm.Debug)
-	sink.LevelPrinters[3] = pterm.Debug
-	sink.LevelPrinters[2] = plogr.DefaultLevelPrinters[0]
-	sink.LevelPrinters[1] = pterm.Success
-	sink.LevelPrinters[0] = pterm.Warning
-	logger := logr.New(sink)
-	logger.V(0).WithName("main").Info("Warning message")
-	logger.V(1).WithName("app").Info("Success message")
-	logger.V(2).WithName("database").Info("Info message", "key", "value")
-	logger.V(3).WithName("controller").Info("Debug message")
-	logger.V(50).WithName("fallback").Info("Fallback message")
 }

--- a/sink_test.go
+++ b/sink_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
-	"github.com/pterm/pterm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -75,11 +74,6 @@ func TestPtermSink_Enabled(t *testing.T) {
 	t.Run("GivenNonExistingLevel_ThenReturnFalse", func(t *testing.T) {
 		enabled := sink.Enabled(10000)
 		assert.False(t, enabled)
-	})
-	t.Run("GivenNonExistingLevel_WhenFallbackPrinterDefined_ThenReturnTrue", func(t *testing.T) {
-		sink = *sink.WithFallbackPrinter(pterm.Debug)
-		enabled := sink.Enabled(10000)
-		assert.True(t, enabled)
 	})
 }
 


### PR DESCRIPTION

## Summary

Now, each level has to be explicitly enabled.
No longer are debug messages being printed if the level isn't explicitly enabled.


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
